### PR TITLE
Should have the CI package installation script

### DIFF
--- a/get-ubuntu-packages.sh
+++ b/get-ubuntu-packages.sh
@@ -1,0 +1,2 @@
+# Install the packages required to build on Ubuntu 14.04 (Trusty Tahr)
+sudo apt-get install -y libncurses5-dev


### PR DESCRIPTION
This is a "backport" of a thing we are going to use from version 0.8 onwards. This is required for CI of the ongoing work on version 0.8.